### PR TITLE
improve gen reqs documentation

### DIFF
--- a/R/gen_requirements.R
+++ b/R/gen_requirements.R
@@ -11,9 +11,33 @@
 #'
 #' @return Nothing is returned.  Results are written to \code{output_path}
 #'
+#' @details Methodology for package matching relies on string pattern matching rather than a more sophisticated method.
+#' This will match most 'standard' ways of referencing libraries in R code.
+#' The following lines of code show examples where the \code{data.table} package will be matched properly:
+#' \itemize{
+#'   \item \code{library(data.table)}
+#'   \item \code{library('data.table')}
+#'   \item \code{library(data.table, warn.conflicts = TRUE)}
+#'   \item \code{require(data.table)}
+#'   \item \code{require('data.table')}
+#'   \item \code{require(data.table, quietly = TRUE)}
+#'   \item \code{pacman::p_load(data.table)}
+#'   \item \code{pacman::p_load('data.table')}
+#'   \item \code{pacman::p_load(data.table, install = FALSE)}
+#'   \item \code{data.table::data.table()}
+#'   \item \code{data.table:::data.table()}
+#' }
+#'
+#' Matching will fail if loading multiple packages with \code{pacman::p_load}; only the first package will be matched.
+#'
+#' Matching will fail if using a character vector to load (i.e. \code{pkg = 'testthat'; library(pkg, character.only = TRUE)}).
+#' This will match \code{pkg} as package instead of \code{testthat}.
+#'
+#'
 #' @examples
 #'
 #' \dontrun{
+#'
 #' generate_requirements('R/*.R')
 #' generate_requirements('R/*.R', output_path='my_requirements.txt')
 #' generate_requirements('R/*.R', output_path='equal_to_requirements.txt', eq_sym='>=')

--- a/R/gen_requirements.R
+++ b/R/gen_requirements.R
@@ -28,10 +28,13 @@
 #'   \item \code{data.table:::data.table()}
 #' }
 #'
-#' Matching will fail if loading multiple packages with \code{pacman::p_load}; only the first package will be matched.
+#' Matching will fail if:
 #'
-#' Matching will fail if using a character vector to load (i.e. \code{pkg = 'testthat'; library(pkg, character.only = TRUE)}).
-#' This will match \code{pkg} as package instead of \code{testthat}.
+#' \itemize{
+#'   \item loading multiple packages with \code{pacman::p_load} (only the first package will be matched)
+#'   \item using a character vector to load; e.g. \code{pkg = 'testthat'; library(pkg, character.only = TRUE)} (will match \code{pkg} as package instead of \code{testthat})
+#'   \item using a string resembling a package load; e.g. \code{'library(fake.package)'} (will match \code{fake.package})
+#' }
 #'
 #'
 #' @examples

--- a/R/gen_requirements.R
+++ b/R/gen_requirements.R
@@ -7,7 +7,7 @@
 #' @param output_path String indicating where to write resulting requirements file to.
 #' @param eq_sym The equality symbol to be used when writing requirements (i.e. package>=1.0.0).
 #'   Use \code{NULL} to not include package versions in your requirements file.
-#' @param rm_missing Should packages not installed locally be exlcuded from output?
+#' @param rm_missing Should packages not installed locally be excluded from output?
 #'
 #' @return Nothing is returned.  Results are written to \code{output_path}
 #'

--- a/man/generate_requirements.Rd
+++ b/man/generate_requirements.Rd
@@ -17,7 +17,7 @@ See \code{?Sys.glob} for more details.}
 \item{eq_sym}{The equality symbol to be used when writing requirements (i.e. package>=1.0.0).
 Use \code{NULL} to not include package versions in your requirements file.}
 
-\item{rm_missing}{Should packages not installed locally be exlcuded from output?}
+\item{rm_missing}{Should packages not installed locally be excluded from output?}
 }
 \value{
 Nothing is returned.  Results are written to \code{output_path}

--- a/man/generate_requirements.Rd
+++ b/man/generate_requirements.Rd
@@ -4,8 +4,9 @@
 \alias{generate_requirements}
 \title{Generate a requirements.txt for your project}
 \usage{
-generate_requirements(glob_paths = "*.R", output_path = "requirements.txt",
-  eq_sym = ">=", rm_missing = FALSE)
+generate_requirements(glob_paths = "*.R",
+  output_path = "requirements.txt", eq_sym = ">=",
+  rm_missing = FALSE)
 }
 \arguments{
 \item{glob_paths}{Character vector of patterns for relative or absolute filepaths. Missing values will be ignored.
@@ -24,9 +25,33 @@ Nothing is returned.  Results are written to \code{output_path}
 \description{
 Generate a requirements file from existing file(s) and installed packages
 }
+\details{
+Methodology for package matching relies on string pattern matching rather than a more sophisticated method.
+This will match most 'standard' ways of referencing libraries in R code.
+The following lines of code show examples where the \code{data.table} package will be matched properly:
+\itemize{
+  \item \code{library(data.table)}
+  \item \code{library('data.table')}
+  \item \code{library(data.table, warn.conflicts = TRUE)}
+  \item \code{require(data.table)}
+  \item \code{require('data.table')}
+  \item \code{require(data.table, quietly = TRUE)}
+  \item \code{pacman::p_load(data.table)}
+  \item \code{pacman::p_load('data.table')}
+  \item \code{pacman::p_load(data.table, install = FALSE)}
+  \item \code{data.table::data.table()}
+  \item \code{data.table:::data.table()}
+}
+
+Matching will fail if loading multiple packages with \code{pacman::p_load}; only the first package will be matched.
+
+Matching will fail if using a character vector to load (i.e. \code{pkg = 'testthat'; library(pkg, character.only = TRUE)}).
+This will match \code{pkg} as package instead of \code{testthat}.
+}
 \examples{
 
 \dontrun{
+
 generate_requirements('R/*.R')
 generate_requirements('R/*.R', output_path='my_requirements.txt')
 generate_requirements('R/*.R', output_path='equal_to_requirements.txt', eq_sym='>=')

--- a/man/generate_requirements.Rd
+++ b/man/generate_requirements.Rd
@@ -43,10 +43,13 @@ The following lines of code show examples where the \code{data.table} package wi
   \item \code{data.table:::data.table()}
 }
 
-Matching will fail if loading multiple packages with \code{pacman::p_load}; only the first package will be matched.
+Matching will fail if:
 
-Matching will fail if using a character vector to load (i.e. \code{pkg = 'testthat'; library(pkg, character.only = TRUE)}).
-This will match \code{pkg} as package instead of \code{testthat}.
+\itemize{
+  \item loading multiple packages with \code{pacman::p_load} (only the first package will be matched)
+  \item using a character vector to load; e.g. \code{pkg = 'testthat'; library(pkg, character.only = TRUE)} (will match \code{pkg} as package instead of \code{testthat})
+  \item using a string resembling a package load; e.g. \code{'library(fake.package)'} (will match \code{fake.package})
+}
 }
 \examples{
 


### PR DESCRIPTION
* adds `#' @details` section to `generate_requirements()` function (screenshots of rendered documentation below)

* I think we might have different versions of `roxygen2`.  The symptom is that when i generated the docs it slightly reformatted `man/load_requirements`.  I did not commit the change, but we should standardize the version of `roxygen2` we're using (I'm currently on `packageVersion('roxygen2') == '6.1.1'`).

*Note* there's a typo in the form of 'exlcuded' below (caught thanks to `devtools::spellcheck`.  I did not retake screenshots, but the typo has been fixed.
![image](https://user-images.githubusercontent.com/16326083/54870872-acb2d880-4d82-11e9-805b-4536ed437065.png)
![image](https://user-images.githubusercontent.com/16326083/54870877-b4727d00-4d82-11e9-9038-59b4d7591e22.png)
![image](https://user-images.githubusercontent.com/16326083/54870882-bb998b00-4d82-11e9-9bb7-6ff585cf00e8.png)
