### PR TITLE
Metacran #26

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ LazyData: true
 Imports:
   devtools (>= 1.13.5),
   packrat (>= 0.4.9),
-  stringr
+  stringr,
+  httr
 Depends: R (>= 2.10)
 RoxygenNote: 6.1.1
 Suggests: 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,4 @@
 export("install_requirements")
 export("generate_requirements")
 importFrom("utils", "installed.packages", "packageVersion", "install.packages")
+importFrom("utils", "tail")

--- a/R/gen_requirements_helpers.R
+++ b/R/gen_requirements_helpers.R
@@ -39,10 +39,11 @@ match_package = function(candidate_lines, package_regex) {
   #' @param package_regex Regex as string to be used to match package references in code.
   #'
   #' @return Character vector of package names matched.
-  lib_matches = stringr::str_match(candidate_lines, package_regex)[,2]
-  lib_matches = lib_matches[!is.na(lib_matches)]
+  lib_matches_list = stringr::str_match_all(candidate_lines, package_regex)
+  lib_matches_str = unlist(lapply(lib_matches_list, function(m) m[, 2]))
+  lib_matches_str = lib_matches_str[!is.na(lib_matches_str)]
 
-  return(lib_matches)
+  return(unique(lib_matches_str))
 }
 
 

--- a/R/requirements_helpers.R
+++ b/R/requirements_helpers.R
@@ -220,7 +220,7 @@ install_reqs = function(reqs, dryrun, verbose = dryrun,
       if(is.na(installed[i])){
         available_versions = get_available_versions(i)
         v = vmess(sprintf(NOT_INSTALLED,i),verbose)
-        version = which.max(available_versions)
+        version = tail(available_versions, i)
         v = vmess(sprintf(INSTALL,i,sprintf(INSTALL_VERSION,version)),verbose)
         if(!dryrun){
           tryCatch(install.packages(i,repos=repo),

--- a/R/requirements_helpers.R
+++ b/R/requirements_helpers.R
@@ -220,7 +220,7 @@ install_reqs = function(reqs, dryrun, verbose = dryrun,
       if(is.na(installed[i])){
         available_versions = get_available_versions(i)
         v = vmess(sprintf(NOT_INSTALLED,i),verbose)
-        version = tail(sort(available_versions), i)
+        version = tail(sort(available_versions), 1)
         v = vmess(sprintf(INSTALL,i,sprintf(INSTALL_VERSION,version)),verbose)
         if(!dryrun){
           tryCatch(install.packages(i,repos=repo),

--- a/R/requirements_helpers.R
+++ b/R/requirements_helpers.R
@@ -220,7 +220,7 @@ install_reqs = function(reqs, dryrun, verbose = dryrun,
       if(is.na(installed[i])){
         available_versions = get_available_versions(i)
         v = vmess(sprintf(NOT_INSTALLED,i),verbose)
-        version = tail(available_versions, i)
+        version = tail(sort(available_versions), i)
         v = vmess(sprintf(INSTALL,i,sprintf(INSTALL_VERSION,version)),verbose)
         if(!dryrun){
           tryCatch(install.packages(i,repos=repo),

--- a/tests/testthat/test_gen_requirements.R
+++ b/tests/testthat/test_gen_requirements.R
@@ -6,11 +6,12 @@ FILE_2 = file.path(TMP_DIR, 'file_2.R')
 FILE_3 = file.path(TMP_DIR, 'file_3.R')
 
 FILE_TEXT_1 = c(
-  'library(fake.package)',
+  'library(fake.package, quietly = TRUE)',
   'require(testthat)',
   'pacman::p_load("dplyr")',
   'requirements::requirements()',
   'devtools:::fake_function()',
+  'stringr::function(readr:::function)',
   'dt[, x := 1]\n'
 )
 
@@ -28,7 +29,9 @@ PACKAGE_LINES_3 = character(0)
 PACKAGE_LINES_ALL = c(PACKAGE_LINES_1, PACKAGE_LINES_2, PACKAGE_LINES_3)
 PACKAGE_LINES_ALL = unique(PACKAGE_LINES_ALL)
 
-PACKAGES_ALL = c('fake.package', 'packrat', 'testthat', 'pacman', 'requirements', 'devtools')
+PACKAGES_1 = c('fake.package', 'testthat', 'dplyr', 'pacman', 'requirements', 'devtools', 'stringr', 'readr')
+PACKAGES_2 = c('packrat')
+PACKAGES_ALL = c(PACKAGES_1, PACKAGES_2)
 
 setup({
   invisible(
@@ -45,7 +48,10 @@ test_that('read_package_lines_from_files', {
 })
 
 test_that('match_packages', {
-  expect_equal(match_packages(PACKAGE_LINES_ALL, PACKAGE_RES), PACKAGES_ALL)
+  expect_equal(
+    sort(match_packages(PACKAGE_LINES_ALL, PACKAGE_RES)),
+    sort(PACKAGES_ALL)
+  )
 })
 
 test_that('safe_package_version', {
@@ -97,7 +103,7 @@ test_that('append_version_requirements', {
 
 test_that('generate_requirements', {
   test_requirements_file = file.path(TMP_DIR, 'requirements.txt')
-  test_glob = file.path(TMP_DIR, '*.R')
+  test_glob = file.path(TMP_DIR, 'file_*.R')
 
   generate_requirements(test_glob, test_requirements_file, eq_sym = NULL)
 
@@ -106,4 +112,3 @@ test_that('generate_requirements', {
     sort(PACKAGES_ALL)
   )
 })
-

--- a/tests/testthat/test_install_requirements.R
+++ b/tests/testthat/test_install_requirements.R
@@ -20,7 +20,6 @@ test_that('Invalid Package Requirement', {
 })
 
 test_that('Requirements Generate Correctly', {
-  browser()
   expect_error(install_requirements(file.path(TMP_DIR,'tmp_req.txt'),
                                       gen = TRUE, packrat = FALSE,
                                       dryrun = TRUE, verbose = TRUE,

--- a/tests/testthat/test_install_requirements.R
+++ b/tests/testthat/test_install_requirements.R
@@ -20,6 +20,7 @@ test_that('Invalid Package Requirement', {
 })
 
 test_that('Requirements Generate Correctly', {
+  browser()
   expect_error(install_requirements(file.path(TMP_DIR,'tmp_req.txt'),
                                       gen = TRUE, packrat = FALSE,
                                       dryrun = TRUE, verbose = TRUE,
@@ -27,14 +28,9 @@ test_that('Requirements Generate Correctly', {
 })
 
 test_that('Getting available package versions', {
-  browser()
-  expect_equal(get_available_versions('mgsub')[1:4],c("1.0.0", "1.5.0", "1.7.0", "1.7.1"))
-  expect_equal(get_available_versions('lexRankr')[1:7],c("0.1.0", "0.2.0", "0.3.0", "0.4.0", "0.4.1", "0.5.0", "0.5.2"))
-  expect_equal(get_available_versions('dplyr')[1:24],c("0.1.1", "0.1.2", "0.1.3", "0.1", "0.2", "0.3.0.1", "0.3.0.2", 
-                                                       "0.3", "0.4.0", "0.4.1", "0.4.2", "0.4.3", "0.5.0", "0.7.0", 
-                                                       "0.7.1", "0.7.2", "0.7.3", "0.7.4", "0.7.5", "0.7.6", "0.7.7", 
-                                                       "0.7.8", "0.8.0", "0.8.0.1"))
-  expect_equal(get_available_versions('readOffice')[1],c("0.2.2"))
+  expect_equal(get_available_versions('mgsub')[1:4],
+               c("1.0.0", "1.5.0", "1.7.0", "1.7.1"))
+
   expect_null(get_available_versions('lexrankR'))
-  
+
 })


### PR DESCRIPTION
Summary of changes

* Pull in `gen_requirements` changes from the prep release branch to pass tests
* Implement `get_available_versions` with `crandb` REST API
  * Adds `httr` as a dependency
  * drops `repo` argument.  We need to discuss the best path forward around this
* Fix bug in finding max available version to pass `devtools::check`
  * The old implementation was using `which.max`.  `which.max` doesn't support character vector input and was throwing warnings/returning `integer(0)`.
  * updated implementation uses `tail(sort(available_versions), 1)` (finds max in char vector and returns `NULL` when `available_versions` is `NULL`

----

lintr-bot still gonna hate this sh*t.  once we get stuff merged im down to go ham on re-styling.