### PR TITLE
simplified install_requirements args

### DIFF
--- a/R/install_requirements.R
+++ b/R/install_requirements.R
@@ -1,9 +1,9 @@
 #' @export
-install_requirements <- function(requirements = file.path(getwd(),"requirements.txt"), 
+install_requirements <- function(requirements = "requirements.txt", 
                                  packrat = FALSE, dryrun = FALSE,
                                  verbose = dryrun, repo = options()$repo[1],
                                  gen = !file.exists(requirements), 
-                                 glob_paths = file.path(dirname(requirements),"*.R"), ...) {
+                                 glob_paths = file.path(dirname(requirements),"*.R")) {
   #' @title Install project requirements
   #'
   #' @description Install (and optionally generate) required packages
@@ -16,7 +16,6 @@ install_requirements <- function(requirements = file.path(getwd(),"requirements.
   #' @param repo What repository should be used to install pacakges?
   #' @param gen Should required packages be generated?
   #' @param glob_paths Character vector of patterns for relative or absolute filepaths. Missing values will be ignored. See ?Sys.glob for more details.
-  #' @param ... Arguments to pass to helper functions called
   #'
   #' @return invisible
   #' @examples
@@ -33,7 +32,7 @@ install_requirements <- function(requirements = file.path(getwd(),"requirements.
   tmp = install_reqs(reqs = reqs,
                      dryrun = dryrun, 
                      verbose = verbose, 
-                     repo = repo, ...)
+                     repo = repo)
 
   if(dryrun) cat("NOTE: This was just a dry run. No packages have been installed.")
   return(invisible(0))

--- a/tests/testthat/test_install_requirements.R
+++ b/tests/testthat/test_install_requirements.R
@@ -18,7 +18,7 @@ test_that('read_requirements_file', {
 })
 
 test_that('process_requirements_file',{
-  expect_type(process_requirements_file('testdata/requirements_1.txt'),'list')
+  expect_type(req1 <- process_requirements_file('testdata/requirements_1.txt'),'list')
   expect_length(process_requirements_file('testdata/requirements_1.txt'), 7)
   expect_length(process_requirements_file('testdata/requirements_1.txt')[['url']], 0)
   expect_equal(process_requirements_file('testdata/requirements_1.txt')[['versioned']],
@@ -78,17 +78,9 @@ writeLines(c('library(mgsub)','require(lexRankr)'),file.path(TMP_DIR,'dummy.R'))
 INST = c("mgsub"="1.5.1.3","lexRankr"="0.4.1","readOffice"="0.2.2")
 
 test_that('Invalid Package Requirement', {
-  expect_error(install_requirements('testdata/requirements_1.txt',
-                                 gen = FALSE, packrat = FALSE,
-                                 dryrun = TRUE, verbose = FALSE,
-                                 dummy = INST))
-})
-
-test_that('Requirements Generate Correctly', {
-  expect_error(install_requirements(file.path(TMP_DIR,'tmp_req.txt'),
-                                      gen = TRUE, packrat = FALSE,
-                                      dryrun = TRUE, verbose = TRUE,
-                                      dummy = INST))
+  expect_error(install_reqs(reqs = req1,
+                            dryrun = TRUE, verbose = FALSE,
+                            dummy = INST))
 })
 
 test_that('Getting available package versions', {


### PR DESCRIPTION
Removed the redundant getwd() from the default value. Also removed the ... as we're moving unit testing to be on smaller units rather than the big wrapper. Removing ... will reduce confusion for end users who won't understand that it only existed to enable testing.

When merged, this will close #27 