### PR TITLE
Validate eq sym

### DIFF
--- a/R/gen_requirements_helpers.R
+++ b/R/gen_requirements_helpers.R
@@ -85,8 +85,9 @@ validate_eq_sym = function(eq_sym) {
   #'
   #' @param eq_sym The equality symbol to be used when writing requirements (i.e. package>=1.0.0).
   #' @return None; exception is raised if invalid symbol
+  stopifnot(length(eq_sym) == 1)
 
-  eq_sym[eq_sym == "="] = COMP_EXACTLY_EQUAL
+  if (eq_sym == "=") return(COMP_EXACTLY_EQUAL)
 
   if (!(eq_sym %in% COMPS)) {
     comps_str = paste(COMPS, collapse = "', '")

--- a/R/gen_requirements_helpers.R
+++ b/R/gen_requirements_helpers.R
@@ -79,10 +79,18 @@ safe_package_version = function(pkg) {
   )
 }
 
-
 validate_eq_sym = function(eq_sym) {
   #' @keywords internal
-  # TODO: implement this
+  #' Raise exception if comparison operator is invalid
+  #'
+  #' @param eq_sym The equality symbol to be used when writing requirements (i.e. package>=1.0.0).
+  #' @return None; exception is raised if invalid symbol
+  if (!(eq_sym %in% COMPS)) {
+    comps_str = paste(COMPS, collapse="', '")
+    error_msg = "'%s' is not a valid comparison operator; valid operators are: '%s'"
+    fmt_error_msg = sprintf(error_msg, eq_sym, comps_str)
+    stop(fmt_error_msg)
+  }
   return(eq_sym)
 }
 

--- a/R/gen_requirements_helpers.R
+++ b/R/gen_requirements_helpers.R
@@ -86,7 +86,7 @@ validate_eq_sym = function(eq_sym) {
   #' @param eq_sym The equality symbol to be used when writing requirements (i.e. package>=1.0.0).
   #' @return None; exception is raised if invalid symbol
   if (!(eq_sym %in% COMPS)) {
-    comps_str = paste(COMPS, collapse="', '")
+    comps_str = paste(COMPS, collapse = "', '")
     error_msg = "'%s' is not a valid comparison operator; valid operators are: '%s'"
     fmt_error_msg = sprintf(error_msg, eq_sym, comps_str)
     stop(fmt_error_msg)

--- a/R/gen_requirements_helpers.R
+++ b/R/gen_requirements_helpers.R
@@ -85,9 +85,9 @@ validate_eq_sym = function(eq_sym) {
   #'
   #' @param eq_sym The equality symbol to be used when writing requirements (i.e. package>=1.0.0).
   #' @return None; exception is raised if invalid symbol
-  
+
   eq_sym[eq_sym == "="] = COMP_EXACTLY_EQUAL
-  
+
   if (!(eq_sym %in% COMPS)) {
     comps_str = paste(COMPS, collapse = "', '")
     error_msg = "'%s' is not a valid comparison operator; valid operators are: '%s'"

--- a/R/gen_requirements_helpers.R
+++ b/R/gen_requirements_helpers.R
@@ -85,6 +85,9 @@ validate_eq_sym = function(eq_sym) {
   #'
   #' @param eq_sym The equality symbol to be used when writing requirements (i.e. package>=1.0.0).
   #' @return None; exception is raised if invalid symbol
+  
+  eq_sym[eq_sym == "="] = COMP_EXACTLY_EQUAL
+  
   if (!(eq_sym %in% COMPS)) {
     comps_str = paste(COMPS, collapse = "', '")
     error_msg = "'%s' is not a valid comparison operator; valid operators are: '%s'"

--- a/tests/testthat/test_gen_requirements.R
+++ b/tests/testthat/test_gen_requirements.R
@@ -122,6 +122,8 @@ test_that("validate_eq_sym", {
   )
 
   expect_equal(validate_eq_sym("=="), "==")
-
   expect_equal(validate_eq_sym("="), "==")
+
+  expect_error(validate_eq_sym(c("==", "==")),
+               regexp = "length\\(eq_sym\\) == 1 is not TRUE")
 })

--- a/tests/testthat/test_gen_requirements.R
+++ b/tests/testthat/test_gen_requirements.R
@@ -114,3 +114,12 @@ test_that("generate_requirements", {
     sort(PACKAGES_ALL)
   )
 })
+
+test_that('validate_eq_sym', {
+  expect_error(
+    validate_eq_sym("42"),
+    regexp = "'42'"
+  )
+  
+  expect_equal(validate_eq_sym("=="), "==")
+})

--- a/tests/testthat/test_gen_requirements.R
+++ b/tests/testthat/test_gen_requirements.R
@@ -115,11 +115,11 @@ test_that("generate_requirements", {
   )
 })
 
-test_that('validate_eq_sym', {
+test_that("validate_eq_sym", {
   expect_error(
     validate_eq_sym("42"),
     regexp = "'42'"
   )
-  
+
   expect_equal(validate_eq_sym("=="), "==")
 })

--- a/tests/testthat/test_gen_requirements.R
+++ b/tests/testthat/test_gen_requirements.R
@@ -122,6 +122,6 @@ test_that("validate_eq_sym", {
   )
 
   expect_equal(validate_eq_sym("=="), "==")
-  
+
   expect_equal(validate_eq_sym("="), "==")
 })

--- a/tests/testthat/test_gen_requirements.R
+++ b/tests/testthat/test_gen_requirements.R
@@ -122,4 +122,6 @@ test_that("validate_eq_sym", {
   )
 
   expect_equal(validate_eq_sym("=="), "==")
+  
+  expect_equal(validate_eq_sym("="), "==")
 })


### PR DESCRIPTION
Addresses #21 

Note, code in the issue returned nothing, but it needed to return the valid `eq_sym` since it's used to build some the requirements file. So I modified the function.