### PR TITLE
Remove `stringr`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ LazyData: true
 Imports:
   remotes (>= 2.0.2),
   packrat (>= 0.4.9),
-  stringr,
   httr
 Depends: R (>= 2.10)
 RoxygenNote: 6.1.1

--- a/R/gen_requirements_helpers.R
+++ b/R/gen_requirements_helpers.R
@@ -33,6 +33,61 @@ read_package_lines_from_files = function(file_paths, filter_words=c("::", "libra
 }
 
 
+str_match_all = function(string, pattern) {
+  #' @keywords internal
+  #' Extract capture groups from vector of strings with regex (made to emulate stringr::str_match_all)
+  #'
+  #' @param string character vector to extract capture groups from
+  #' @param pattern len 1 character vector containing regex to use for matching/capture group extraction
+  #' @return character vector containing captured output found in string
+  #'
+  #' @examples
+  #' str_match_all(c('test', 'best'), '(.)est')
+  #' # [[1]]
+  #' #      [,1]   [,2]
+  #' # [1,] "test" "t"
+  #' #
+  #' # [[2]]
+  #' #      [,1]   [,2]
+  #' # [1,] "best" "b"
+  #'
+  #' str_match_all(c('test', 'best'), 'x')
+  #' # [[1]]
+  #' #      [,1]
+  #' #
+  #' # [[2]]
+  #' #      [,1]
+
+  # Below implementation taken from last example in ?grep documentation & modified
+  # > There is no gregexec() yet, but one can emulate it by running
+  # > regexec() on the regmatches obtained via gregexpr().
+  matches_list = lapply(regmatches(string, gregexpr(pattern, string)), function(e) {
+    matches = regmatches(e, regexec(pattern, e))
+
+    do.call(rbind, matches)
+  })
+
+  # Elements of string that weren't matched by pattern are NULL in matches_list.
+  # The below process replaces NULL elements with a row-less matrix that matches
+  # the column number non-NULL elements.
+  null_matches = vapply(matches_list, is.null, logical(1))
+  n_null_matches = sum(null_matches)
+
+  if (n_null_matches == 0) return(matches_list)
+
+  if (n_null_matches == length(matches_list)) {
+    null_matrix_placeholder = matrix(character(0), nrow = 0, ncol = 1)
+  } else {
+    non_null_n_col = max(vapply(matches_list[!null_matches], ncol, integer(1)))
+    null_matrix_placeholder = matrix(character(0), nrow = 0, ncol = non_null_n_col)
+  }
+
+  matches_list[null_matches] = rep(list(null_matrix_placeholder), n_null_matches)
+
+  return(matches_list)
+}
+
+
 match_package = function(candidate_lines, package_regex) {
   #' @keywords internal
   #' Match valid package names from character vector of lines of R code
@@ -41,7 +96,7 @@ match_package = function(candidate_lines, package_regex) {
   #' @param package_regex Regex as string to be used to match package references in code.
   #'
   #' @return Character vector of package names matched.
-  lib_matches_list = stringr::str_match_all(candidate_lines, package_regex)
+  lib_matches_list = str_match_all(candidate_lines, package_regex)
   lib_matches_str = unlist(lapply(lib_matches_list, function(m) m[, 2]))
   lib_matches_str = lib_matches_str[!is.na(lib_matches_str)]
 

--- a/tests/testthat/test-gen_requirements.R
+++ b/tests/testthat/test-gen_requirements.R
@@ -51,6 +51,30 @@ test_that("read_package_lines_from_files", {
   expect_equal(read_package_lines_from_files(FILES), PACKAGE_LINES_ALL)
 })
 
+test_that("str_match_all", {
+  expect_equal(
+    str_match_all("test", "test"),
+    list(structure("test", .Dim = c(1L, 1L)))
+  )
+
+  expect_equal(
+    str_match_all(c("test", "best"), "(.)est"),
+    list(structure(c("test", "t"), .Dim = 1:2),
+         structure(c("best", "b"), .Dim = 1:2))
+  )
+
+  expect_equal(
+    str_match_all(c("test", "nope"), "(.)est"),
+    list(structure(c("test", "t"), .Dim = 1:2),
+         structure(character(0), .Dim = c(0L, 2L)))
+  )
+
+  expect_equal(
+    str_match_all(c("nope"), "(.)est"),
+    list(structure(character(0), .Dim = 0:1))
+  )
+})
+
 test_that("match_packages", {
   expect_equal(match_packages(character(0), PACKAGE_RES), character(0))
 


### PR DESCRIPTION
Replace use of `stringr::str_match_all()` with a custom implementation that is designed to mimic `stringr::str_match_all()`.  

The helper function is named `str_match_all()` to show this similarity.  Is this naming choice a good idea or confusing?

Additionally, please advise if you see room for simplification of the current implementation of `str_match_all()`.

---

Ideally, we would solve #58, but this will allow for the old logic to stay without needing the dependency of `stringr` for a single function call.