### PR TITLE
avoid duplicated/conflicting reqs from lockfile #73

### DIFF
--- a/R/gen_requirements.R
+++ b/R/gen_requirements.R
@@ -79,7 +79,9 @@ generate_requirements = function(glob_paths = "*.R",
     matched_packages_df = matched_packages_df[!is.na(matched_packages_df[["version"]]), ]
   }
 
-  requirements_vector = unique(append_version_requirements(matched_packages_df, eq_sym))
+  matched_packages_df = rm_dup_matched_packages(matched_packages_df)
+
+  requirements_vector = append_version_requirements(matched_packages_df, eq_sym)
 
   write_requirements_file(requirements_vector, output_path)
 }

--- a/R/gen_requirements.R
+++ b/R/gen_requirements.R
@@ -60,13 +60,26 @@ generate_requirements = function(glob_paths = "*.R",
   package_text_lines = read_package_lines_from_files(file_paths)
 
   matched_packages = match_packages(package_text_lines, PACKAGE_RES)
-  sorted_matched_packages = sort(matched_packages)
+  matched_packages_df = data.frame(name = matched_packages,
+                                   version = rep(NA_character_, length(matched_packages)),
+                                   stringsAsFactors = FALSE)
 
-  versioned_matched_packages = append_version_requirements(sorted_matched_packages, eq_sym, rm_missing)
-
-  write_requirements_file(versioned_matched_packages, output_path)
+  if (!is.null(eq_sym)) {
+    matched_packages_df[["version"]] = vapply(matched_packages_df[["name"]], safe_package_version, character(1))
+  }
 
   if (!is.null(packrat_lock_path)) {
-    packrat_to_requirements(packrat_lock_path, output_path, eq_sym, append = TRUE)
+    matched_packages_df = rbind(
+      matched_packages_df,
+      read_reqs_from_lockfile(packrat_lock_path, eq_sym)
+    )
   }
+
+  if (rm_missing) {
+    matched_packages_df = matched_packages_df[!is.na(matched_packages_df[["version"]]), ]
+  }
+
+  requirements_vector = unique(append_version_requirements(matched_packages_df, eq_sym))
+
+  write_requirements_file(requirements_vector, output_path)
 }

--- a/R/gen_requirements_helpers.R
+++ b/R/gen_requirements_helpers.R
@@ -40,11 +40,16 @@ read_reqs_from_lockfile = function(lockfile_path = "packrat/packrat.lock", eq_sy
   #'
   #' read_packages_from_lockfile(eq_sym = NULL)
   #' [1] "BH" "DT"
-  lockfile_lines = readLines(lockfile_path)
+  lockfile_lines = trimws(readLines(lockfile_path))
 
   package_names = extract_lockfile_info(lockfile_lines, "Package")
 
-  if (is.null(eq_sym) | length(package_names) == 0) return(package_names)
+  matched_packages_df = data.frame(name = package_names,
+                                   version = rep(NA_character_, length(package_names)),
+                                   stringsAsFactors = FALSE)
+
+  if (is.null(eq_sym) | nrow(matched_packages_df) == 0) return(matched_packages_df)
+
   eq_sym = validate_eq_sym(trimws(eq_sym))
 
   version_numbers = extract_lockfile_info(lockfile_lines, "Version")
@@ -53,11 +58,9 @@ read_reqs_from_lockfile = function(lockfile_path = "packrat/packrat.lock", eq_sy
     stop("Malformed lockfile.  Each package listed in lockfile must also have a version.")
   }
 
-  mapply(paste0,
-         trimws(package_names),
-         eq_sym,
-         trimws(version_numbers),
-         USE.NAMES = FALSE)
+  matched_packages_df[["version"]] = version_numbers
+
+  return(matched_packages_df)
 }
 
 
@@ -70,7 +73,6 @@ read_package_lines_from_file = function(file_path, filter_words) {
   #'
   #' @return Character vector containing package referencing lines from \code{file_path}.
   all_file_lines = readLines(file_path)
-  all_file_lines = strip_comments(all_file_lines, remove_additional_file = FALSE)
 
   package_lines_re = paste(filter_words, collapse = "|")
   package_lines = all_file_lines[grep(package_lines_re, all_file_lines)]
@@ -193,7 +195,7 @@ safe_package_version = function(pkg) {
   #' @return Package version as string; \code{NA} if unavailable.
   tryCatch(
     expr = {
-      return(packageVersion(pkg))
+      return(as.character(packageVersion(pkg)))
     },
     error = function(e) {
       return(NA_character_)
@@ -220,47 +222,30 @@ validate_eq_sym = function(eq_sym) {
 }
 
 
-append_version_requirement = function(pkg, eq_sym=COMP_GTE, rm_missing=FALSE) {
+append_version_requirements = function(matched_packages_df, eq_sym=COMP_GTE) {
   #' @keywords internal
-  #' Paste version requirements to character vector of package names
+  #' Paste requirement names and version numbers together
   #'
-  #' @param package_names String containing package name.
+  #' @param matched_packages_df data.frame with columns c("name", "version")
   #' @param eq_sym The equality symbol to be used when writing requirements (i.e. package>=1.0.0).
   #'   Use \code{NULL} to not include package versions in your requirements file.
-  #' @param rm_missing Should packages not installed locally be exlcuded from output?
-  #'
-  #' @return Character vector of versioned package names;
-  #'   \code{NA} if package unavailable and \code{isTRUE(rm_missing)}.
-  pkg_version = safe_package_version(pkg)
-
-  if (rm_missing & is.na(pkg_version)) {
-    versioned_package = NA_character_
-  } else if (is.na(pkg_version) | is.null(eq_sym)) {
-    versioned_package = pkg
-  } else {
-    eq_sym = validate_eq_sym(eq_sym)
-    versioned_package = paste0(pkg, eq_sym, pkg_version)
-  }
-
-  return(versioned_package)
-}
-
-
-append_version_requirements = function(package_names, eq_sym=COMP_GTE, rm_missing=FALSE) {
-  #' @keywords internal
-  #' Paste version requirements to character vector of package names
-  #'
-  #' @param package_names Character vector of package names.
-  #' @param eq_sym The equality symbol to be used when writing requirements (i.e. package>=1.0.0).
-  #'   Use \code{NULL} to not include package versions in your requirements file.
-  #' @param rm_missing Should packages not installed locally be exlcuded from output?
   #'
   #' @return Character vector of versioned package names.
-  versioned_packages = vapply(package_names, function(p) {
-    append_version_requirement(p, eq_sym, rm_missing)
-  }, character(1), USE.NAMES = FALSE)  # nolint
+  if (nrow(matched_packages_df) == 0) return(character(0))
+  if (is.null(eq_sym)) return(sort(trimws(matched_packages_df$name)))
 
-  return(versioned_packages[!is.na(versioned_packages)])
+  eq_sym = validate_eq_sym(eq_sym)
+
+  versioned_packages_df = matched_packages_df[!is.na(matched_packages_df[["version"]]), ]
+  unversioned_packages_df = matched_packages_df[is.na(matched_packages_df[["version"]]), ]
+
+  versioned_requirements = mapply(paste0,
+                                  trimws(versioned_packages_df[["name"]]),
+                                  eq_sym,
+                                  trimws(versioned_packages_df[["version"]]),
+                                  USE.NAMES = FALSE)
+
+  sort(c(versioned_requirements, unversioned_packages_df[["name"]]))
 }
 
 

--- a/R/generate_from_packrat.R
+++ b/R/generate_from_packrat.R
@@ -22,6 +22,8 @@ packrat_to_requirements = function(packrat_lock_path = "packrat/packrat.lock",
   #' }
   #' @export
   matched_packages_df = read_reqs_from_lockfile(packrat_lock_path, eq_sym)
+  matched_packages_df = rm_dup_matched_packages(matched_packages_df)
+
   requirements_vector = unique(append_version_requirements(matched_packages_df, eq_sym))
 
   write_requirements_file(requirements_vector, output_path, append)

--- a/R/generate_from_packrat.R
+++ b/R/generate_from_packrat.R
@@ -21,6 +21,8 @@ packrat_to_requirements = function(packrat_lock_path = "packrat/packrat.lock",
   #' packrat_to_requirements(output_path = "overwrite_requirements.txt", append = FALSE)
   #' }
   #' @export
-  lockfile_requirements = read_reqs_from_lockfile(packrat_lock_path, eq_sym)
-  write_requirements_file(lockfile_requirements, output_path, append)
+  matched_packages_df = read_reqs_from_lockfile(packrat_lock_path, eq_sym)
+  requirements_vector = unique(append_version_requirements(matched_packages_df, eq_sym))
+
+  write_requirements_file(requirements_vector, output_path, append)
 }

--- a/tests/testthat/test-gen_requirements.R
+++ b/tests/testthat/test-gen_requirements.R
@@ -251,3 +251,21 @@ test_that("validate_eq_sym", {
     regexp = "length\\(eq_sym\\) == 1 is not TRUE"
   )
 })
+
+test_that("rm_dup_matched_packages", {
+  input_df = data.frame(name = "testthat",
+                        version = c("0.0.0", "1.0.0"),
+                        stringsAsFactors = FALSE)
+
+  expected_output_df = input_df[2, ]
+
+  expect_equal(
+    rm_dup_matched_packages(input_df),
+    expected_output_df
+  )
+
+  expect_warning(
+    rm_dup_matched_packages(input_df),
+    regexp = "testthat"
+  )
+})

--- a/tests/testthat/test-gen_requirements.R
+++ b/tests/testthat/test-gen_requirements.R
@@ -253,19 +253,24 @@ test_that("validate_eq_sym", {
 })
 
 test_that("rm_dup_matched_packages", {
-  input_df = data.frame(name = "testthat",
-                        version = c("0.0.0", "1.0.0"),
+  input_df = data.frame(name = c("testthat", "testthat", "testthat", "DT", "DT", "mgsub", "mgsub", "BH"),
+                        version = c("0.0.0", "2.0.0", "1.0.0", "42.0.0", "3.0.0", "1.0.0", "1.0.0", "1.0.0"),
                         stringsAsFactors = FALSE)
 
-  expected_output_df = input_df[2, ]
+  expected_output_df = input_df[c(8, 4, 7, 2), ]
+  row.names(expected_output_df) = NULL
 
   expect_equal(
-    rm_dup_matched_packages(input_df),
+    suppressWarnings(rm_dup_matched_packages(input_df)),
     expected_output_df
   )
 
   expect_warning(
     rm_dup_matched_packages(input_df),
-    regexp = "testthat"
+    regexp = "DT, testthat"
+  )
+
+  expect_silent(
+    rm_dup_matched_packages(input_df[6:7, ])
   )
 })


### PR DESCRIPTION
* refactor gen_req package discovery to rely on data.frame for easier deduping relative to version
* add `rm_dup_matched_packages()` function to dedupe packages and keep most recent version when conflicts occur
* add the use of `rm_dup_matched_packages()` to `generate_requirements()` & `packrat_to_requirements()`