### PR TITLE
fix #96

### DIFF
--- a/R/rip_freeze_helpers.R
+++ b/R/rip_freeze_helpers.R
@@ -237,7 +237,9 @@ append_version_requirements = function(matched_packages_df, eq_sym=COMP_GTE) {
   eq_sym = validate_eq_sym(eq_sym)
 
   versioned_packages_df = matched_packages_df[!is.na(matched_packages_df[["version"]]), ]
-  unversioned_packages_df = matched_packages_df[is.na(matched_packages_df[["version"]]), ]
+  unversioned_requirements = matched_packages_df[is.na(matched_packages_df[["version"]]), "name"]
+
+  if (nrow(versioned_packages_df) == 0) return(unversioned_requirements)
 
   versioned_requirements = mapply(paste0,
                                   trimws(versioned_packages_df[["name"]]),
@@ -245,7 +247,7 @@ append_version_requirements = function(matched_packages_df, eq_sym=COMP_GTE) {
                                   trimws(versioned_packages_df[["version"]]),
                                   USE.NAMES = FALSE)
 
-  sort(c(versioned_requirements, unversioned_packages_df[["name"]]))
+  sort(c(versioned_requirements, unversioned_requirements))
 }
 
 

--- a/tests/testthat/test-rip_freeze.R
+++ b/tests/testthat/test-rip_freeze.R
@@ -183,6 +183,11 @@ test_that("append_version_requirements", {
     append_version_requirements(expected_matched_package_df, eq_sym = NULL),
     c("DT", "testthat")
   )
+
+  expect_equal(
+    append_version_requirements(expected_matched_package_df[1, ]),
+    "testthat"
+  )
 })
 
 test_that("write_requirements_file", {


### PR DESCRIPTION
Fix issue where `rip_freeze()` fails if none of the packages detected are installed.  This lead to an error in `append_version_requirements()` (see #96 for more detail). 