### PR TITLE
Bmewing patch issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,3 @@
-```markdown
 ## Expected Behavior
 
 
@@ -16,5 +15,3 @@
   - Package Version:
   - R Version:
   - OS:
-```
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-```markdown
 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**
 
 *Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*
@@ -26,5 +25,3 @@ Run `lintr::lint_package()` and `cyclocomp::cyclocomp_package_dir()` to ensure c
 **Closing issues**
 
 Put `closes #XXXX` in your comment to make it clear what issue this is related to.
-```
-


### PR DESCRIPTION
Correcting, I believe the templates for issues and pull requests to remove the markdown tag.