### PR TITLE
Fixing #106

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ inst/doc
 .RData
 .Ruserdata
 *.Rproj
+*.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ r:
   - release
   - devel
 
-r_github_packages:
-  - jimhester/lintr
+r_packages:
+  - lintr
+  - covr
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,6 @@ Depends: R (>= 2.10)
 RoxygenNote: 6.1.1
 Suggests: 
     testthat,
-    covr,
     knitr,
     rmarkdown
 VignetteBuilder: knitr


### PR DESCRIPTION
Travis CI builds have been breaking. Based on my experience with other R repos having similar issues, I believe installing lintr from CRAN will address the issue. This additionally removes covr from the suggested packages list because it's not used locally when developing, only through the Travis CI build.

There are no new tests because the failures (I believe) is external to the code base in the package itself.

closes #106 
